### PR TITLE
ci(workflows/publish): add step to load NPM_TOKEN in .npmrc

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
@@ -16,6 +18,8 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
+      - name: "Setup NPM_TOKEN"
+        run: echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
       - name: "Install packages"
         run: npm install
       - name: "Build package"


### PR DESCRIPTION
The publish workflows is not working since 0.3.0, i think that the problem is that NPM_TOKEN is expired or that NPM_TOKEN is not loading properly in the .npmrc before publish step

This is the issue I raised in the issues forum #19 